### PR TITLE
Fix issue #2, reducing the oauth scope permissions required from user

### DIFF
--- a/app/lib/Bot.scala
+++ b/app/lib/Bot.scala
@@ -1,0 +1,17 @@
+package lib
+
+import java.nio.file.{Paths, Files, Path}
+
+import com.madgag.github.OkGitHub
+
+object Bot {
+
+  val okGitHub = new OkGitHub(Paths.get("/tmp/submitgit/working-dir/http-response-cache/"))
+
+  import play.api.Play.current
+  val config = play.api.Play.configuration
+
+  val accessToken = config.getString("github.botAccessToken").get
+
+  def conn() = okGitHub.conn(accessToken)
+}

--- a/app/lib/MailType.scala
+++ b/app/lib/MailType.scala
@@ -108,7 +108,7 @@ object MailType {
     override def afterSending(pr: GHPullRequest, commitsAndPatches: Seq[(GHPullRequestCommitDetail, Patch)], messageId: String) {
       val mailingListLinks = Project.byRepoId(pr.id.repo).mailingList.archives.map(a => s"[${a.providerName}](${a.linkFor(messageId)})").mkString(", ")
       pr.comment(
-        s"I've sent this PR to the mailing list with [_submitGit_](https://github.com/rtyley/submitgit) - " +
+        s"${pr.getUser.atLogin} sent this to the mailing list with [_submitGit_](https://github.com/rtyley/submitgit) - " +
           s"here on $mailingListLinks []($messageId)")
     }
   }

--- a/app/lib/actions/Actions.scala
+++ b/app/lib/actions/Actions.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success, Try}
 
 
 object Actions {
-  private val authScopes = Seq("user:email", "public_repo")
+  private val authScopes = Seq("user:email")
 
   val GitHubAuthenticatedAction = com.madgag.playgithub.auth.Actions.githubAction(authScopes)(Auth.authClient)
 
@@ -26,7 +26,7 @@ object Actions {
     override protected def refine[A](request: GHRequest[A]): Future[Either[Result, GHRepoRequest[A]]] = Future {
       Either.cond(Project.byRepoId.contains(repoId), {
         val gitHub = request.gitHub
-        val repo = gitHub.getRepository(repoId.fullName)
+        val repo = Bot.conn().getRepository(repoId.fullName)
         new GHRepoRequest(gitHub, repo, request)}, Forbidden("Not a supported repo"))
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,6 +15,8 @@ application.langs="en"
 google.analytics.id=${?GOOGLE_ANALYTICS_ID}
 
 github {
+    botAccessToken=${SUBMITGIT_GITHUB_ACCESS_TOKEN} # Needs 'public_repo' scop in order to comment on PR
+
     clientId=${GITHUB_APP_CLIENT_ID}
     clientSecret=${GITHUB_APP_CLIENT_SECRET}
 }


### PR DESCRIPTION
The `public_repo` requirement is dropped, with users now only required to give the `user:email` [scope](https://developer.github.com/v3/oauth/#scopes) so we can get their email address.

Note that existing users will get a slightly alarming-looking notification from GitHub to tell them that the required permissions have been reduced:

!['Removed permissions' is highlighted in red](https://cloud.githubusercontent.com/assets/52038/7860692/2ae50980-0543-11e5-9f6d-01d001ef0fab.png)

The PR comment generated when a user sends mail to the list is now made by the @submitgit account.

Conditional response caching with OkHttp is now also enabled so that there's less risk of running out of GitHub API quota - given that now we don't take advantage of the user's quota.

cc @gitster for https://github.com/rtyley/submitgit/issues/2

http://thread.gmane.org/gmane.comp.version-control.git/269699/focus=269733
