### PR TITLE
href the 'submitGit' brand/link in the header back to the home page

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -14,7 +14,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="#">submitGit</a>
+                <a class="navbar-brand" href="@routes.Application.index()">submitGit</a>
             </div>
 
                 <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
Hat-tip to Matthieu Moy (@moy):

> The submitGit link on the top left does nothing for me. I would expect
> to come back to the home page of submitGit.

http://thread.gmane.org/gmane.comp.version-control.git/269699/focus=269732