### PR TITLE
Very quick hack to address the time machine problem

### DIFF
--- a/app/lib/actions/requests.scala
+++ b/app/lib/actions/requests.scala
@@ -24,8 +24,7 @@ object Requests {
     lazy val userOwnsPR = user == pr.getUser
 
     lazy val commitsAndPatchesF: Future[Seq[(GHPullRequestCommitDetail, Patch)]] = {
-      val commits = pr.listCommits().toSeq
-      //require(commits.size < 50)
+      val commits = pr.listCommits().toSeq.reverse
 
       val patchUrl = pr.getPatchUrl.toString
       for {


### PR DESCRIPTION
As noted by @gitster on https://github.com/git/git/pull/138, submitGit's threading of multi-patch series was busted:

http://thread.gmane.org/gmane.comp.version-control.git/269711/focus=269730

This was due to me not realising that the GitHub API returns commit lists for PRs in reverse-chronological order...

This may not be the best fix - soon it could be time to bite the bullet and make submitGit keep it's own in-app copy of the git/git repo - which would remove ambiguity around chrono-vs-topo too.