### PR TITLE
Add a `From:` line when the author differs from the sender, fixes #8

### DIFF
--- a/app/lib/MailType.scala
+++ b/app/lib/MailType.scala
@@ -27,7 +27,7 @@ sealed trait MailType {
 
 object MailType {
   
-  def userEmailString(user: GHMyself): String = s"${user.displayName} <${user.primaryEmail.getEmail}>"
+  def userEmailString(user: GHMyself) = s"${user.displayName} <${user.primaryEmail.getEmail}>"
   
   val all = Seq(Preview, Live)
 

--- a/app/lib/actions/requests.scala
+++ b/app/lib/actions/requests.scala
@@ -7,7 +7,7 @@ import com.madgag.playgithub.auth.GHRequest
 import com.squareup.okhttp
 import com.squareup.okhttp.OkHttpClient
 import lib._
-import lib.model.{Commit, PatchCommit}
+import lib.model.{UserIdent, Commit, PatchCommit}
 import org.kohsuke.github.{GHPullRequest, GHRepository, GitHub}
 import play.api.mvc.Request
 
@@ -33,7 +33,15 @@ object Requests {
         resp <- new OkHttpClient().execute(new okhttp.Request.Builder().url(patchUrl).build())
       } yield {
         val patch = resp.body.string
-        val commits = ghCommits.map(ghc => Commit(ghc.getSha.asObjectId, ghc.getCommit.getMessage))
+        val commits = ghCommits.map { ghc =>
+          val ghCommit = ghc.getCommit
+          Commit(
+            ghc.getSha.asObjectId,
+            UserIdent.from(ghCommit.getAuthor),
+            UserIdent.from(ghCommit.getCommitter),
+            ghCommit.getMessage
+          )
+        }
         PatchCommit.from(commits, patch)
       }
     }

--- a/app/lib/model/Commit.scala
+++ b/app/lib/model/Commit.scala
@@ -2,6 +2,11 @@ package lib.model
 
 import org.eclipse.jgit.lib.ObjectId
 
-case class Commit(id: ObjectId, message: String) {
-  val subject= message.lines.next()
+case class Commit(
+  id: ObjectId,
+  author: UserIdent,
+  committer: UserIdent,
+  message: String
+) {
+  val subject = message.lines.next()
 }

--- a/app/lib/model/UserIdent.scala
+++ b/app/lib/model/UserIdent.scala
@@ -1,0 +1,11 @@
+package lib.model
+
+import org.kohsuke.github.GitUser
+
+case class UserIdent(name: String, email: String) {
+  lazy val userEmailString = s"$name <$email>"
+}
+
+object UserIdent {
+  def from(gu: GitUser) = UserIdent(gu.getName, gu.getEmail)
+}

--- a/test/lib/model/PatchBombSpec.scala
+++ b/test/lib/model/PatchBombSpec.scala
@@ -1,0 +1,29 @@
+package lib.model
+
+import lib.Email.Addresses
+import org.eclipse.jgit.lib.ObjectId
+import org.specs2.mutable.Specification
+
+class PatchBombSpec extends Specification {
+  val patchCommit = {
+    val author = UserIdent("bob", "bob@x.com")
+    PatchCommit(Patch(ObjectId.zeroId, "PATCHBODY"), Commit(ObjectId.zeroId, author, author, "COMMITMESSAGE"))
+  }
+
+  def patchBombFrom(text: String) = PatchBomb(
+    Seq(patchCommit),
+    Addresses(from = text),
+    footer = "FOOTER"
+  )
+  
+  "Patch bomb" should {
+    "add a in-body 'From' header when commit author differs from email sender" in {
+      patchBombFrom("fred <fred@y.com>").emails.head.bodyText must startWith(s"From: bob <bob@x.com>\n\n${patchCommit.patch.body}")
+    }
+
+    "not add an in-body 'From' header when the commit author matches the email sender" in {
+      patchBombFrom("bob <bob@x.com>").emails.head.bodyText must not contain "From:"
+    }
+
+  }
+}


### PR DESCRIPTION
This is for a user submitting a PR containing commits by other people, the convention is to add a in-body `From:` header naming the author, like this:

http://article.gmane.org/gmane.comp.version-control.git/271211/raw

Thanks to @dscho for telling me about this behaviour with https://github.com/rtyley/submitgit/issues/8! :sparkles: 
