### PR TITLE
Allow setting a custom subject prefix on patch emails

### DIFF
--- a/app/lib/PRMailSettings.scala
+++ b/app/lib/PRMailSettings.scala
@@ -1,0 +1,10 @@
+package lib
+
+import play.api.libs.json.Json
+
+case class PRMailSettings(subjectPrefix: String)
+
+object PRMailSettings {
+  implicit val formats = Json.format[PRMailSettings]
+}
+

--- a/app/views/fragments/emailAddresses.scala.html
+++ b/app/views/fragments/emailAddresses.scala.html
@@ -1,8 +1,17 @@
 @(addresses: lib.Email.Addresses)
-<dl class="dl-horizontal">
-    <dt>From:</dt><dd>@addresses.from</dd>
-    @if(addresses.to.nonEmpty){<dt>To:</dt><dd>@addresses.to.mkString(", ")</dd>}
-    @if(addresses.cc.nonEmpty){<dt>Cc:</dt><dd>@addresses.cc.mkString(", ")</dd>}
-    @if(addresses.bcc.nonEmpty){<dt>Bcc:</dt><dd>@addresses.bcc.mkString(", ")</dd>}
-    @for(replyTo <- addresses.replyTo) {<dt>Reply-To:</dt><dd>@replyTo</dd>}
-</dl>
+@display(label: String, ids: Seq[String]) = {
+    @if(ids.nonEmpty) {
+        <label class="col-sm-4 control-label">@label</label>
+        <div class="col-sm-8">
+            <p class="form-control-static">@ids.mkString(", ")</p>
+        </div>
+    }
+}
+
+<div class="form-group">
+    @display("From", Seq(addresses.from))
+    @display("To", addresses.to)
+    @display("Cc", addresses.cc)
+    @display("Bcc", addresses.bcc)
+    @display("Reply-To", addresses.replyTo.toSeq)
+</div>

--- a/app/views/fragments/sendTabContent.scala.html
+++ b/app/views/fragments/sendTabContent.scala.html
@@ -1,25 +1,40 @@
-@(mailType: lib.MailType, proposedMail: lib.ProposedMail, isDefault: Boolean, btnClass: String)(implicit req: GHPRRequest[_])
+@(mailType: lib.MailType, proposedMail: lib.ProposedMail, isDefault: Boolean, btnClass: String
+        )(implicit req: GHPRRequest[_], prMailSettings: Form[lib.PRMailSettings], messages: Messages)
 @import helper._
-
+@implicitFieldConstructor = @{ b3.horizontal.fieldConstructor("col-md-4", "col-md-8") }
 
 <div role="tabpanel" class="tab-pane @if(isDefault) { fade in active }" id="mail-@mailType.slug">
-@fragments.emailAddresses(proposedMail.addresses)
-@if(proposedMail.errors.nonEmpty) {
-    <div class="alert alert-warning" role="alert">
-        <ul>
-        @for(error <- proposedMail.errors) {
-            <li>@error</li>
-        }
-        </ul>
-    </div>
-}
-
-@form(routes.Application.mailPullRequest(req.pr.id, mailType)) {
+@b3.form(routes.Application.mailPullRequest(req.pr.id, mailType)) {
     @CSRF.formField
-    <button
-    class="btn @btnClass btn-lg"
-    value="send"
-    @if(proposedMail.errors.nonEmpty) { disabled="disabled" }
-    >Send</button>
+
+    @if(proposedMail.errors.nonEmpty) {
+        <div class="alert alert-warning" role="alert">
+            <ul>
+            @for(error <- proposedMail.errors) {
+                <li>@error</li>
+            }
+            </ul>
+        </div>
+    }
+
+    @fragments.emailAddresses(proposedMail.addresses)
+
+    @b3.inputWrapped("text", prMailSettings("subjectPrefix"), '_label -> "Subject prefix", 'placeholder -> "PATCH", 'maxlength -> "20") { input =>
+        <div class="input-group">
+            <span class="input-group-addon">[</span>
+            @input
+            <span class="input-group-addon">]</span>
+        </div>
+    }
+
+    <div class="form-group">
+        <div class="col-sm-offset-4 col-sm-8">
+            <button
+            class="btn @btnClass btn-lg"
+            value="send"
+                @if(proposedMail.errors.nonEmpty) { disabled="disabled" }
+            >Send</button>
+        </div>
+    </div>
 }
 </div>

--- a/app/views/fragments/sendTabs.scala.html
+++ b/app/views/fragments/sendTabs.scala.html
@@ -1,4 +1,5 @@
-@(defaultMailTab: lib.MailType, proposedMailByType: Map[lib.MailType,lib.ProposedMail])(implicit req: GHPRRequest[_])
+@(defaultMailTab: lib.MailType, proposedMailByType: Map[lib.MailType,lib.ProposedMail]
+        )(implicit req: GHPRRequest[_], prMailSettings: Form[lib.PRMailSettings], messages: Messages)
 @import lib.MailType
 @import MailType.{Live, Preview}
 

--- a/app/views/reviewPullRequest.scala.html
+++ b/app/views/reviewPullRequest.scala.html
@@ -1,4 +1,5 @@
-@(pullRequest: org.kohsuke.github.GHPullRequest, user: org.kohsuke.github.GHMyself, proposedMailByType: Map[lib.MailType,lib.ProposedMail])(implicit req: GHPRRequest[_])
+@(pullRequest: org.kohsuke.github.GHPullRequest, user: org.kohsuke.github.GHMyself, proposedMailByType: Map[lib.MailType,lib.ProposedMail]
+        )(implicit req: GHPRRequest[_], prMailSettings: Form[lib.PRMailSettings], messages: Messages)
 @main {
     <div class="row">
         <ol class="breadcrumb">

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,10 @@ TwirlKeys.templateImports ++= Seq(
 
 routesImport ++= Seq("lib._","com.madgag.github._","controllers.Binders._","org.eclipse.jgit.lib.ObjectId")
 
-resolvers += Resolver.sonatypeRepo("releases")
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases"),
+  Resolver.sonatypeRepo("snapshots")
+)
 
 libraryDependencies ++= Seq(
   cache,
@@ -34,6 +37,7 @@ libraryDependencies ++= Seq(
   "com.madgag" %% "play-git-hub" % "1.1",
   "com.typesafe.akka" %% "akka-agent" % "2.3.2",
   "org.webjars" % "bootstrap" % "3.3.4",
+  "com.adrianhurt" %% "play-bootstrap3" % "0.4.4-P24-SNAPSHOT",
   "org.webjars.bower" % "octicons" % "2.2.3",
   "com.lihaoyi" %% "fastparse" % "0.1.7",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,19 @@
+In http://git-scm.com/docs/git-format-patch :
+
+--subject-prefix=<Subject-Prefix>
+Instead of the standard [PATCH] prefix in the subject line, instead use [<Subject-Prefix>]. This allows for useful naming of a patch series, and can be combined with the --numbered option.
+
+[PATCH v2 ...]
+[RFC/PATCH ...]
+[WIP/PATCH v4 6/8]
+[PATCH]
+[RFC/WIP PATCH 06/11]
+[PATCH/WIP 4/8]
+
+Matthieu Moy said: I found no way to specify a version like [PATCH v2 ...]. Similarly, there could be a way to say [RFC/PATCH ...].
+
+
+
 Potential features TODO:
 
 * When closing a PR 'cos it's been posted, link to http://mid.gmane.org/1234567890.1234567890@example.com so we can see the discussion.


### PR DESCRIPTION
Instead of the standard [PATCH] prefix in the subject line, allow setting a custom prefix like [PATCH v2 ...], much like the `--subject-prefix` option in [`git format-patch`](http://git-scm.com/docs/git-format-patch).

Matthieu Moy (@moy) [mentioned](http://thread.gmane.org/gmane.comp.version-control.git/269699/focus=269732):

> * I found no way to specify a version like [PATCH v2 ...]. Similarly, there could be a way to say [RFC/PATCH ...].

![image](https://cloud.githubusercontent.com/assets/52038/8241730/ead4b6e4-1602-11e5-84f7-5cd20d749652.png)