### PR TITLE
Remove specs2 in favour of ScalaTest: scalaz not on Maven Central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,7 @@ libraryDependencies ++= Seq(
   "org.jsoup" % "jsoup" % "1.8.2",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3-1",
-  "org.specs2" %% "specs2-core" % "2.4.17" % "test",
-  "org.specs2" %% "specs2-junit" % "2.4.17" % "test",
+  "org.scalatestplus" %% "play" % "1.4.0-M3",
   "com.amazonaws" % "aws-java-sdk-ses" % "1.9.37",
   "com.sun.mail" % "javax.mail" % "1.5.3"
 )

--- a/test/lib/MailArchiveSpec.scala
+++ b/test/lib/MailArchiveSpec.scala
@@ -2,11 +2,11 @@ package lib
 
 import javax.mail.internet.MailDateFormat
 
-import org.specs2.mutable.Specification
+import org.scalatestplus.play.PlaySpec
 
 import scalax.io.Resource
 
-class MailArchiveSpec extends Specification {
+class MailArchiveSpec extends PlaySpec {
   "Google Groups" should {
     val submitGitGoogleGroup = GoogleGroup("submitgit-test")
 

--- a/test/lib/PatchParsingSpec.scala
+++ b/test/lib/PatchParsingSpec.scala
@@ -3,11 +3,11 @@ package lib
 import com.madgag.git._
 import fastparse._
 import lib.model.PatchParsing
-import org.specs2.mutable.Specification
+import org.scalatestplus.play.PlaySpec
 
 import scalax.io.Resource
 
-class PatchParsingSpec extends Specification {
+class PatchParsingSpec extends PlaySpec {
 
   val pull187PatchesText = Resource.fromClasspath("samples/bfg/pull87/github.patch").string
 

--- a/test/lib/model/PatchBombSpec.scala
+++ b/test/lib/model/PatchBombSpec.scala
@@ -2,9 +2,9 @@ package lib.model
 
 import lib.Email.Addresses
 import org.eclipse.jgit.lib.ObjectId
-import org.specs2.mutable.Specification
+import org.scalatestplus.play.PlaySpec
 
-class PatchBombSpec extends Specification {
+class PatchBombSpec extends PlaySpec {
   val patchCommit = {
     val author = UserIdent("bob", "bob@x.com")
     PatchCommit(Patch(ObjectId.zeroId, "PATCHBODY"), Commit(ObjectId.zeroId, author, author, "COMMITMESSAGE"))


### PR DESCRIPTION
All recent version of specs2 [have a dependency on Scalaz](https://github.com/etorreborre/specs2/issues/295#issuecomment-95981615), which hasn't been published to Maven Central [for the past year](https://github.com/scalaz/scalaz-stream/issues/258#issuecomment-95975632).

Although specs2 has given me some better error messages in the past, this persistent issue personally annoys me enough to move away from specs2.
