### PR TITLE
Appropriately set subject prefix when user sets in-reply-to

### DIFF
--- a/app/lib/model/SubjectPrefix.scala
+++ b/app/lib/model/SubjectPrefix.scala
@@ -1,0 +1,36 @@
+package lib.model
+
+import fastparse.all._
+
+case class SubjectPrefix(descriptor: String, version: Option[Int] = None) {
+  lazy val suggestsNext = copy(version = Some(version.fold(2)(_ + 1)))
+
+  override lazy val toString = (descriptor +: version.map("v"+_).toSeq).mkString(" ")
+}
+
+object SubjectPrefixParsing {
+  val number: P[Int] = P( CharIn('0'to'9').rep(1).!.map(_.toInt) )
+
+  val version: P[Int] = P( CharIn("vV") ~ number )
+
+  val patchIndexAndBombSize = P(number ~"/" ~ number)
+
+  val word: P[String] = P(CharsWhile(!Set('\n',' ', ']').contains(_)).!)
+
+  val nonDescriptorTerms = version | patchIndexAndBombSize
+
+  val descriptorWord = word.filter(!nonDescriptorTerms.parse(_).isInstanceOf[Result.Success[_]])
+
+  val descriptor: P[String] = P( descriptorWord.rep(1, sep = " ").! )
+
+  val patchPrefix: P[SubjectPrefix] =
+    P( "[" ~ descriptor ~ (" " ~ version).? ~ (" " ~ patchIndexAndBombSize).map(_ => ()).? ~ "]").map(SubjectPrefix.tupled)
+
+  def parse(subjectLine: String): Option[SubjectPrefix] = {
+
+    patchPrefix.parse(subjectLine) match {
+      case Result.Success(subjectPrefix, _) => Some(subjectPrefix)
+      case _ => None
+    }
+  }
+}

--- a/app/views/fragments/head.scala.html
+++ b/app/views/fragments/head.scala.html
@@ -8,6 +8,7 @@
     <script type="text/javascript" src="@routes.Assets.at("lib/timeago/jquery.timeago.js")"></script>
     <script type="text/javascript" src="@routes.Assets.at("lib/handlebars/dist/handlebars.js")"></script>
     <script type="text/javascript" src="@routes.Assets.at("javascript/messageIdPicker.js")"></script>
+    <script type="text/javascript" src="@routes.Assets.at("javascript/changeHighlighter.js")"></script>
     <link rel="stylesheet" href="@routes.Assets.at("lib/octicons/octicons/octicons.css")">
     <link rel="stylesheet" href="@routes.Assets.at("lib/typeahead.js-bootstrap3.less/typeahead.css")">
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">

--- a/app/views/fragments/sendTabContent.scala.html
+++ b/app/views/fragments/sendTabContent.scala.html
@@ -26,7 +26,7 @@
         @CSRF.formField
 
     @b3.inputWrapped("text", prMailSettings("subjectPrefix"), '_label -> "Subject prefix", 'placeholder -> "PATCH", 'maxlength -> "20") { input =>
-        <div class="input-group">
+        <div class="input-group" id="@mailType.slug-subject-prefix">
             <span class="input-group-addon">[</span>
             @input
             <span class="input-group-addon">]</span>
@@ -51,7 +51,8 @@
         @fragments.mailIdent(MessageSummary("{{id}}", "{{subject}}", java.time.ZonedDateTime.now, Addresses("{{addresses.from}}"), "{{groupLink}}"))
     </script>
     <script>
-        jQuery("#@mailType.slug-in-reply-to").messageIdPicker({
+        var inReplyToFieldContainer = jQuery("#@mailType.slug-in-reply-to");
+        inReplyToFieldContainer.messageIdPicker({
             hint: true,
             highlight: true,
             minLength: 3,
@@ -71,6 +72,9 @@
                 empty: '<div class="empty-message">Unable to find any Messages that match that Id</div>',
                 suggestion: Handlebars.compile(jQuery("#entry-template").html())
             }
+        });
+        inReplyToFieldContainer.find(".input-group .typeahead").bind('typeahead:select', function (ev, suggestion) {
+            jQuery("#@mailType.slug-subject-prefix input").changeVal(suggestion.suggestsPrefix);
         });
     </script>
 

--- a/public/javascript/changeHighlighter.js
+++ b/public/javascript/changeHighlighter.js
@@ -1,0 +1,16 @@
+(function ( jQ ) {
+    jQ.fn.changeVal = function(newVal) {
+        var highlighterClass = "highlighter";
+
+        return this.each(function(index, elem) {
+            var jqElem = jQ(elem);
+
+            if (newVal && jqElem.val() != newVal) {
+                jqElem.val(newVal);
+                jqElem.bind('animationend', function(){ jqElem.removeClass(highlighterClass); });
+                jqElem.addClass(highlighterClass);
+            }
+        });
+    };
+
+}( jQuery ));

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -46,3 +46,16 @@ pre .long {
 .tt-dropdown-menu .tt-suggestion {
     white-space: normal;
 }
+
+@keyframes highlight {
+    0% {
+        background: yellow;
+    }
+    100% {
+        background: none;
+    }
+}
+
+.highlighter {
+    animation: highlight 1s;
+}

--- a/test/lib/model/SubjectPrefixSpec.scala
+++ b/test/lib/model/SubjectPrefixSpec.scala
@@ -1,0 +1,21 @@
+package lib.model
+
+import lib.model.SubjectPrefixParsing.parse
+import org.scalatestplus.play.PlaySpec
+
+class SubjectPrefixSpec extends PlaySpec {
+  "SubjectPrefixParsing" should {
+    "be happy if there is no patch version" in {
+      parse("[PATCH] send-email") mustBe Some(SubjectPrefix("PATCH"))
+    }
+    "extract version" in {
+      parse("[PATCH v3] send-email") mustBe Some(SubjectPrefix("PATCH", Some(3)))
+    }
+    "extract version when patch index is present" in {
+      parse("[PATCH v3 5/7] send-email") mustBe Some(SubjectPrefix("PATCH", Some(3)))
+    }
+    "work for prefix text that isn't just 'PATCH'" in {
+      parse("[RFC/PATCH] send-email") mustBe Some(SubjectPrefix("RFC/PATCH"))
+    }
+  }
+}


### PR DESCRIPTION
This requires parsing the subject prefix of the in-reply-to message, and setting the new subject prefix to an incremented version of that. E.g. '[WIP/RFC v3 0/17] Add this thing' becomes 'WIP/RFC v4' in the subject prefix field.

![output](https://cloud.githubusercontent.com/assets/52038/8512814/6dff20c6-234c-11e5-9fd0-eb83ee509b0b.gif)

Using a CSS3 yellow-fade animation to show that we've changed the subject prefix - the technique is a little more than a decade old:

https://signalvnoise.com/archives/000558.php