### PR TITLE
Create a simple, single part, text/plain e-mail instead of multi part

### DIFF
--- a/app/lib/Email.scala
+++ b/app/lib/Email.scala
@@ -50,14 +50,7 @@ case class Email(
     headers.foreach(t => msg.addHeader(t._1, t._2))
     addresses.replyTo.foreach(r => msg.setReplyTo(Array(new InternetAddress(r))))
 
-    // Add a MIME part to the message
-    val mp = new MimeMultipart()
-
-    val part = new MimeBodyPart()
-    part.setContent(bodyText, "text/plain")
-    mp.addBodyPart(part)
-
-    msg.setContent(mp)
+    msg.setContent(bodyText, "text/plain")
 
     val b = new ByteArrayOutputStream()
 


### PR DESCRIPTION
Here's an untested proposed fix for #17.