### PR TITLE
Send simple, single part, text/plain e-mail rather than multi-part

### DIFF
--- a/app/lib/Email.scala
+++ b/app/lib/Email.scala
@@ -50,20 +50,11 @@ case class Email(
     headers.foreach(t => msg.addHeader(t._1, t._2))
     addresses.replyTo.foreach(r => msg.setReplyTo(Array(new InternetAddress(r))))
 
-    // Add a MIME part to the message
-    val mp = new MimeMultipart()
-
-    val part = new MimeBodyPart()
-    part.setContent(bodyText, "text/plain")
-    mp.addBodyPart(part)
-
-    msg.setContent(mp)
+    msg.setText(bodyText)
 
     val b = new ByteArrayOutputStream()
 
     msg.writeTo(b)
-
-    msg.writeTo(System.out);
 
     ByteBuffer.wrap(b.toByteArray)
 


### PR DESCRIPTION
Fix #17 - as the multi-part mime message was objectionable. Many many thanks to @sschuberth, who [pointed out](https://github.com/rtyley/submitgit/issues/17#issuecomment-120142422) that https://en.wikipedia.org/wiki/JavaMail#Examples shows how to "Send a simple, single part, text/plain e-mail" using the JavaMail API, and he is obviously totally, completely, and absolutely right, even tho' I didn't think JavaMail did that.
