### PR TITLE
Ensure email addresses in SMTP headers are correctly escaped

### DIFF
--- a/app/lib/Email.scala
+++ b/app/lib/Email.scala
@@ -11,11 +11,11 @@ import lib.Email.Addresses
 
 object Email {
   case class Addresses(
-    from: String,
-    to: Seq[String] = Seq.empty,
-    cc: Seq[String] = Seq.empty,
-    bcc: Seq[String] = Seq.empty,
-    replyTo: Option[String] = None
+    from: InternetAddress,
+    to: Seq[InternetAddress] = Seq.empty,
+    cc: Seq[InternetAddress] = Seq.empty,
+    bcc: Seq[InternetAddress] = Seq.empty,
+    replyTo: Option[InternetAddress] = None
   )
 }
 
@@ -37,9 +37,9 @@ case class Email(
     val msg = new MimeMessage(s)
 
     // Sender and recipient
-    msg.setFrom(new InternetAddress(addresses.from))
-    def setRecipients(typ: Message.RecipientType, recipients: Seq[String]) {
-      if (recipients.nonEmpty) msg.setRecipients(typ, recipients.map(new InternetAddress(_)).toArray[Address])
+    msg.setFrom(addresses.from)
+    def setRecipients(typ: Message.RecipientType, recipients: Seq[InternetAddress]) {
+      if (recipients.nonEmpty) msg.setRecipients(typ, recipients.toArray[Address])
     }
 
     setRecipients(RecipientType.TO, addresses.to)
@@ -48,7 +48,7 @@ case class Email(
 
     msg.setSubject(subject)
     headers.foreach(t => msg.addHeader(t._1, t._2))
-    addresses.replyTo.foreach(r => msg.setReplyTo(Array(new InternetAddress(r))))
+    addresses.replyTo.foreach(r => msg.setReplyTo(Array(r)))
 
     msg.setText(bodyText)
 

--- a/app/lib/MailArchive.scala
+++ b/app/lib/MailArchive.scala
@@ -3,6 +3,7 @@ package lib
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.temporal.ChronoField._
 import java.time.{LocalDateTime, ZoneId}
+import javax.mail.internet.InternetAddress
 
 import com.madgag.okhttpscala._
 import com.netaporter.uri.Uri
@@ -83,7 +84,12 @@ case class Gmane(groupName: String) extends MailArchive with MessageSummaryByRaw
 object Marc {
   val Git = Marc("git")
 
-  def deobfuscate(emailOrMessageId: String) = emailOrMessageId.replace(" () ","@").replace(" ! ", ".")
+  def deobfuscate(emailOrMessageId: String) = emailOrMessageId
+    .replace(" () ","@")
+    .replace(" ! ", ".")
+    .replace("&lt;","<")
+    .replace("&gt;",">")
+
 
   /*
    * Hacks EVERYWHERE - MARC unfortunately doesn't expose this data in a nice format for us
@@ -95,7 +101,7 @@ object Marc {
       header.outerHtml.trim.stripSuffix(":") -> value.asInstanceOf[Element].html()
     }).toMap
     val messageId = deobfuscate(headerMap("Message-ID"))
-    val from = deobfuscate(headerMap("From"))
+    val from = new InternetAddress(deobfuscate(headerMap("From")))
 
     val ISO_LOCAL_TIME = new DateTimeFormatterBuilder().appendValue(HOUR_OF_DAY).appendLiteral(':').appendValue(MINUTE_OF_HOUR).optionalStart.appendLiteral(':').appendValue(SECOND_OF_MINUTE).toFormatter
     val ISO_LOCAL_DATE_TIME = new DateTimeFormatterBuilder().parseCaseInsensitive.append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral('T').append(ISO_LOCAL_TIME).toFormatter
@@ -157,7 +163,7 @@ case class GoogleGroup(groupName: String) extends MailArchive with MessageSummar
   def linkFor(messageId: String) = s"https://groups.google.com/d/msgid/$groupName/$messageId"
 
   // submitgit-test@googlegroups.com
-  val emailAddress = s"$groupName@googlegroups.com"
+  val emailAddress = new InternetAddress(s"$groupName@googlegroups.com")
 
   val mailingList = MailingList(emailAddress, Seq(this))
 

--- a/app/lib/MailType.scala
+++ b/app/lib/MailType.scala
@@ -1,5 +1,7 @@
 package lib
 
+import javax.mail.internet.InternetAddress
+
 import com.github.nscala_time.time.Imports._
 import com.madgag.github.Implicits._
 import controllers.routes
@@ -27,8 +29,12 @@ sealed trait MailType {
 
 object MailType {
   
-  def userEmailString(user: GHMyself) = s"${user.displayName} <${user.primaryEmail.getEmail}>"
-  
+  def internetAddress(user: GHMyself) =
+    internetAddressFor(user.primaryEmail.getEmail, user.displayName)
+
+  def internetAddressFor(emailAddress: String, displayName: String) =
+    new InternetAddress(emailAddress, displayName)
+
   val all = Seq(Preview, Live)
 
   val bySlug = all.map(mt => mt.slug -> mt).toMap
@@ -51,8 +57,8 @@ object MailType {
     }
 
     override def addressing(mailingList: MailingList, user: GHMyself) = Email.Addresses(
-      from = "submitGit <submitgit@gmail.com>",
-      to = Seq(userEmailString(user))
+      from = new InternetAddress("submitGit <submitgit@gmail.com>"),
+      to = Seq(internetAddress(user))
     )
 
     override val subjectPrefix = Some("TEST")
@@ -76,7 +82,7 @@ object MailType {
     override def footer(pr: GHPullRequest)(implicit request: RequestHeader): String = pr.getHtmlUrl.toString
 
     override def addressing(mailingList: MailingList, user: GHMyself) = {
-      val userEmail = userEmailString(user)
+      val userEmail = internetAddress(user)
       Email.Addresses(
         from = userEmail,
         to = Seq(mailingList.emailAddress),

--- a/app/lib/ProjectRepo.scala
+++ b/app/lib/ProjectRepo.scala
@@ -1,11 +1,13 @@
 package lib
 
+import javax.mail.internet.InternetAddress
+
 import com.madgag.github.RepoId
 import lib.model.MessageSummary
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class MailingList(emailAddress: String, archives: Seq[MailArchive]) {
+case class MailingList(emailAddress: InternetAddress, archives: Seq[MailArchive]) {
   def lookupMessage(query: String)(implicit ec: ExecutionContext): Future[Seq[MessageSummary]] =
     Future.find(archives.map(_.lookupMessage(query)))(_.nonEmpty).map(_.toSeq.flatten)
 }
@@ -13,7 +15,7 @@ case class MailingList(emailAddress: String, archives: Seq[MailArchive]) {
 object Project {
   val Git = Project(
     RepoId("git", "git"),
-    MailingList("git@vger.kernel.org", Seq(
+    MailingList(new InternetAddress("git@vger.kernel.org"), Seq(
       Gmane.Git,
       Marc.Git
       // MailArchiveDotCom("git@vger.kernel.org") -- message-id search appears broken

--- a/app/lib/aws/SesAsyncHelpers.scala
+++ b/app/lib/aws/SesAsyncHelpers.scala
@@ -55,8 +55,8 @@ object SesAsyncHelpers {
 
     def send(email: Email)(implicit ec: ExecutionContext): Future[String] = {
       val rawEmailRequest = new SendRawEmailRequest(new RawMessage(email.toMimeMessage))
-      rawEmailRequest.setDestinations(email.addresses.to)
-      rawEmailRequest.setSource(email.addresses.from)
+      rawEmailRequest.setDestinations(email.addresses.to.map(_.toString))
+      rawEmailRequest.setSource(email.addresses.from.toString)
       sendRawEmailFuture(rawEmailRequest).map(resp => s"${resp.getMessageId}@eu-west-1.amazonses.com")
     }
   }

--- a/app/views/fragments/emailAddresses.scala.html
+++ b/app/views/fragments/emailAddresses.scala.html
@@ -1,7 +1,7 @@
 @(addresses: lib.Email.Addresses)(implicit fc : views.html.b3.B3FieldConstructor)
+@import javax.mail.internet.InternetAddress
 
-
-    @display(label: String, ids: Seq[String]) = {
+    @display(label: String, ids: Seq[InternetAddress]) = {
     @if(ids.nonEmpty) {
         @b3.static(label) { @ids.mkString(", ")}
 

--- a/app/views/fragments/sendTabContent.scala.html
+++ b/app/views/fragments/sendTabContent.scala.html
@@ -49,7 +49,7 @@
     }
 
     <script id="entry-template" type="text/x-handlebars-template">
-        @fragments.mailIdent(MessageSummary("{{id}}", "{{subject}}", java.time.ZonedDateTime.now, Addresses("{{addresses.from}}"), "{{groupLink}}"))
+        @fragments.mailIdent(MessageSummary("{{id}}", "{{subject}}", java.time.ZonedDateTime.now, Addresses(new javax.mail.internet.InternetAddress("{{addresses.from}}")), "{{groupLink}}"))
     </script>
     <script>
         jQuery(function() {

--- a/test/lib/MailArchiveSpec.scala
+++ b/test/lib/MailArchiveSpec.scala
@@ -38,7 +38,7 @@ class MailArchiveSpec extends PlaySpec with ScalaFutures with IntegrationPatienc
       submitGitGoogleGroup.url mustEqual "https://groups.google.com/forum/#!forum/submitgit-test"
     }
     "derive correct email address" in {
-      submitGitGoogleGroup.emailAddress mustEqual "submitgit-test@googlegroups.com"
+      submitGitGoogleGroup.emailAddress.toString mustEqual "submitgit-test@googlegroups.com"
     }
     "give correct raw article url" in {
       submitGitGoogleGroup.rawUrlFor("/forum/#!msg/submitgit-test/-cq4q1w7jyY/A-EH61BAZaUJ").toString mustEqual
@@ -83,6 +83,10 @@ class MailArchiveSpec extends PlaySpec with ScalaFutures with IntegrationPatienc
     }
   }
   "MARC" should {
+    "deobfuscate this crazy stuff" in {
+      Marc.deobfuscate("Roberto Tyley &lt;roberto.tyley () gmail ! com&gt;") mustEqual
+        "Roberto Tyley <roberto.tyley@gmail.com>"
+    }
     "have MessageSummary parsed (totally hackishly) from html - because the alternate raw version excludes headers" in {
       val message =
         Marc.messageSummaryFor(Resource.fromClasspath("samples/mailarchives/marc/m.143228360912708.html").string)

--- a/test/lib/MailTypeSpec.scala
+++ b/test/lib/MailTypeSpec.scala
@@ -1,0 +1,10 @@
+package lib
+
+import org.scalatestplus.play.PlaySpec
+
+class MailTypeSpec extends PlaySpec {
+  "Email address construction" should {
+    MailType.internetAddressFor("c@m.com", "Cédric Malard").toString mustEqual
+      "=?UTF-8?Q?C=C3=A9dric_Malard?= <c@m.com>"
+  }
+}

--- a/test/lib/model/PatchBombSpec.scala
+++ b/test/lib/model/PatchBombSpec.scala
@@ -1,5 +1,7 @@
 package lib.model
 
+import javax.mail.internet.InternetAddress
+
 import lib.Email.Addresses
 import org.eclipse.jgit.lib.ObjectId
 import org.scalatestplus.play.PlaySpec
@@ -12,7 +14,7 @@ class PatchBombSpec extends PlaySpec {
 
   def patchBombFrom(text: String) = PatchBomb(
     Seq(patchCommit),
-    Addresses(from = text),
+    Addresses(from = new InternetAddress(text)),
     footer = "FOOTER"
   )
   


### PR DESCRIPTION
Should fix https://github.com/rtyley/submitgit/issues/23, kindly reported by @cmalard.

Sigh - I thought, from a fairly reasonable look at the javadoc of `javax.mail.internet.InternetAddress`, that it would store a safely encoded string representation if I used it's one-arg constructor with eg, '`Cédric Malard <c@m.com>`' - but no! So, got to use it's two-arg constructor - and pass `InternetAddress`s around everywhere instead...

