### PR TITLE
Don't add a 'From:' header to the body if the email is a 'noreply'

### DIFF
--- a/test/lib/model/PatchBombSpec.scala
+++ b/test/lib/model/PatchBombSpec.scala
@@ -7,25 +7,42 @@ import org.eclipse.jgit.lib.ObjectId
 import org.scalatestplus.play.PlaySpec
 
 class PatchBombSpec extends PlaySpec {
-  val patchCommit = {
-    val author = UserIdent("bob", "bob@x.com")
-    PatchCommit(Patch(ObjectId.zeroId, "PATCHBODY"), Commit(ObjectId.zeroId, author, author, "COMMITMESSAGE"))
-  }
 
-  def patchBombFrom(text: String) = PatchBomb(
+  val bob = UserIdent("bob", "bob@x.com")
+  val fred = UserIdent("fred", "fred@y.com")
+
+  def patchCommitAuthoredBy(author: UserIdent) =
+    PatchCommit(Patch(ObjectId.zeroId, "PATCHBODY"), Commit(ObjectId.zeroId, author, author, "COMMITMESSAGE"))
+
+
+  def patchBombFrom(user: UserIdent, patchCommit: PatchCommit) = PatchBomb(
     Seq(patchCommit),
-    Addresses(from = new InternetAddress(text)),
+    Addresses(from = new InternetAddress(user.userEmailString)),
     footer = "FOOTER"
   )
   
   "Patch bomb" should {
     "add a in-body 'From' header when commit author differs from email sender" in {
-      patchBombFrom("fred <fred@y.com>").emails.head.bodyText must startWith(s"From: bob <bob@x.com>\n\n${patchCommit.patch.body}")
+      val patchCommit = patchCommitAuthoredBy(bob)
+      val patchBomb = patchBombFrom(fred, patchCommit)
+
+      patchBomb.emails.head.bodyText must startWith(s"From: bob <bob@x.com>\n\n${patchCommit.patch.body}")
     }
 
     "not add an in-body 'From' header when the commit author matches the email sender" in {
-      patchBombFrom("bob <bob@x.com>").emails.head.bodyText must not contain "From:"
+      val patchBomb = patchBombFrom(bob, patchCommitAuthoredBy(bob))
+
+      patchBomb.emails.head.bodyText must not include "From:"
     }
 
+    "not add an in-body 'From' header when the commit author used a 'noreply' address" in {
+      // http://article.gmane.org/gmane.comp.version-control.git/286879
+      val mrNoReply = UserIdent("Peter Dave Hello", "peterdavehello@users.noreply.github.com")
+      val patchBomb = patchBombFrom(bob, patchCommitAuthoredBy(mrNoReply))
+
+      val text = patchBomb.emails.head.bodyText
+
+      text must not include "From:"
+    }
   }
 }


### PR DESCRIPTION
The old logic included a 'From:' in-body header if the author of the commit was different to the person who was sending the email. However, commits generated through GitHub's interface often (always?) have an author email of `githubusername@users.noreply.github.com`, which is [definitely _not_ preferable](http://article.gmane.org/gmane.comp.version-control.git/286879).

PatchBomb emails by SubmitGit are always sent 'from' the user's *primary* email address in GitHub.

See also: https://github.com/rtyley/submitgit/issues/28

cc @peterdavehello