### PR TITLE
replace Gmane archive with PublicInbox

### DIFF
--- a/app/lib/MailArchive.scala
+++ b/app/lib/MailArchive.scala
@@ -70,12 +70,12 @@ trait MessageSummaryByRawResourceFromRedirect extends MailArchive {
   }
 }
 
-case class Gmane(groupName: String) extends MailArchive with MessageSummaryByRawResourceFromRedirect {
-  val providerName = "Gmane"
+case class PublicInbox(groupName: String) extends MailArchive with MessageSummaryByRawResourceFromRedirect {
+  val providerName = "public-inbox"
 
-  val url = s"http://dir.gmane.org/gmane.$groupName"
+  val url = s"https://public-inbox.org/$groupName/"
 
-  def linkFor(messageId: String) = s"http://mid.gmane.org/$messageId"
+  def linkFor(messageId: String) = s"https://public-inbox.org/$groupName/$messageId/"
 
   override def rawUrlFor(articleUrl: Uri) = articleUrl / "raw"
 }
@@ -139,8 +139,8 @@ case class Marc(groupName: String) extends MailArchive {
   }
 }
 
-object Gmane {
-  val Git = Gmane("comp.version-control.git")
+object PublicInbox {
+  val Git = PublicInbox("git")
 }
 
 case class MailArchiveDotCom(emailAddress: String) extends MailArchive {

--- a/app/lib/ProjectRepo.scala
+++ b/app/lib/ProjectRepo.scala
@@ -16,7 +16,7 @@ object Project {
   val Git = Project(
     RepoId("git", "git"),
     MailingList(new InternetAddress("git@vger.kernel.org"), Seq(
-      Gmane.Git,
+      PublicInbox.Git,
       Marc.Git
       // MailArchiveDotCom("git@vger.kernel.org") -- message-id search appears broken
     ))

--- a/test/lib/MailArchiveSpec.scala
+++ b/test/lib/MailArchiveSpec.scala
@@ -64,19 +64,19 @@ class MailArchiveSpec extends PlaySpec with ScalaFutures with IntegrationPatienc
       }
     }
   }
-  "Gmane" should {
+  "PublicInbox" should {
     "have a proper link for a message-id" in {
-      Gmane.Git.linkFor("1431830650-111684-1-git-send-email-shawn@churchofgit.com").toString mustEqual
-        "http://mid.gmane.org/1431830650-111684-1-git-send-email-shawn@churchofgit.com"
+      PublicInbox.Git.linkFor("1431830650-111684-1-git-send-email-shawn@churchofgit.com").toString mustEqual
+        "https://public-inbox.org/git/1431830650-111684-1-git-send-email-shawn@churchofgit.com/"
     }
     "give correct raw article url" in {
-      Gmane.Git.rawUrlFor("http://article.gmane.org/gmane.comp.version-control.git/269205").toString mustEqual
-        "http://article.gmane.org/gmane.comp.version-control.git/269205/raw"
+      PublicInbox.Git.rawUrlFor("https://public-inbox.org/git/1431830650-111684-1-git-send-email-shawn@churchofgit.com/").toString mustEqual
+        "https://public-inbox.org/git/1431830650-111684-1-git-send-email-shawn@churchofgit.com/raw"
     }
     "get message data" in {
       assume(Network.isAvailable)
       val messageId = "1431830650-111684-1-git-send-email-shawn@churchofgit.com"
-      whenReady(Gmane.Git.lookupMessage(messageId)) { s =>
+      whenReady(PublicInbox.Git.lookupMessage(messageId)) { s =>
         val messageSummary = s.head
         messageSummary.id mustEqual messageId
         messageSummary.subject mustEqual "[PATCH] daemon: add systemd support"


### PR DESCRIPTION
The gmane web interface is down and not likely to ever come up again. Most Git developers have moved to using public-inbox.org as the preferred archive.

This drops gmane and adds public-inbox (essentially by just converting Gmane over, since the URL schemes are quite similar).

It doesn't _quite_ pass the tests. There are two issues:

  1. Generating "raw" URLs is done with the URI object's "add a path component" magic. But since public-inbox message URLs end with a slash, we get a doubled slash (i.e., "//raw"). I couldn't figure out any less hacky way to do this than converting the URI to a string, doing string manipulation, and then re-parsing it. Surely there's a better way?

  2. The "get message data" test fails. This may be related to (1), because I think the lookupMessage() method is going to ask for the raw message (and the doubled slashes cause public-inbox to complain).